### PR TITLE
fixes #6 - Display more than 30 contributors

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
                });
  
         toolbox.api.Repositories
-               .getRepoContributors(org, repo)
+               .getRepoContributors(org, repo, {qs: { per_page: 100}})
                .then(function(contributors) {
                  var usernames = contributors.map(function(c) { 
                    return '<a href="https://github.com/' + c.login + '">@' + c.login + '</a>';


### PR DESCRIPTION
The functions defined in community-toolbox.js are not being used in index.html. So added the option of "per_page" directly in index.html

fixes #6 