### PR TITLE
Show number of contributors (#10) and add pagination support

### DIFF
--- a/dist/community-toolbox.js
+++ b/dist/community-toolbox.js
@@ -79251,11 +79251,44 @@ CommunityToolbox = function CommunityToolbox(org, repo) {
        .then(callback);
   }
 
-  function getRepoContributors(callback, _options) {
-    _options = _options || options;
-    api.Repositories
-       .getRepoContributors(org, repo, _options)
-       .then(callback);
+  function getRepoContributors(org, repo) {
+
+    var getPages = api.Repositories
+           .getRepoContributors(org, repo, {method: "HEAD", qs: { sort: 'pushed', direction: 'desc', per_page: 100 } })
+           .then(function(contribData) {
+             var headers = contribData;
+             var parsed = parse(headers['link']);
+             totalPages = parseInt(parsed.last.page);
+             return totalPages;
+           });
+
+    //define totalContributors
+    var totalContributors = 0;
+
+    // get data given the page number
+    function getData(curPage){
+      api.Repositories
+            .getRepoContributors(org, repo, { method:"GET", qs: { sort: 'pushed', direction: 'desc', per_page: 100, page:curPage } })
+            .then(function(contributors) {
+              var usernames = contributors.map(function(c) {
+                return '<a href="https://github.com/' + c.login + '">@' + c.login + '</a>';
+              });
+              var avatars = contributors.map(function(c) {
+                return '<a href="https://github.com/' + c.login + '"><img width="100px" src="' + c.avatar_url + '"></a>';
+              });
+              totalContributors += contributors.length;
+              //push data to UI
+              ui.insertContributors(totalContributors, usernames, avatars);
+            });
+    }
+
+    var promises = [];
+    getPages.then(function(totalPages){
+      for(var i = 1; i <= totalPages; i++) {
+        getData(i);
+      }
+    });
+
   }
 
   function displayIssuesForRepo(org, repo, label, selector) {
@@ -79319,9 +79352,21 @@ function insertIssue(issue, el) {
   $(el).append(generateIssueHtml(issue.title, body, issue.html_url, issue));
 }
 
+//Check if function executed so we can add a comma
+var insertContributorsExec = false;
+
+function insertContributors(totalContributors, usernames, avatars){
+  if(insertContributorsExec) $('.contributors > .usernames').append(', ');
+  $('.contributors-head').html('Contributors ('+totalContributors+')');
+  $('.contributors > .usernames').append(usernames.join(', '));
+  $('.contributors > .avatars').append(avatars.join());
+  insertContributorsExec=true;
+}
+
 module.exports = {
   generateIssueHtml: generateIssueHtml,
-  insertIssue: insertIssue
+  insertIssue: insertIssue,
+  insertContributors: insertContributors
 };
 
 },{"moment":270}]},{},[398]);

--- a/index.html
+++ b/index.html
@@ -138,44 +138,7 @@
                  .then(displayIssues('.candidates'));
 
           // compile and display all contributors for given org/repo:
-          // get number of pages
-          var getPages = toolbox.api.Repositories
-                 .getRepoContributors(org, repo, {method: "HEAD", qs: { sort: 'pushed', direction: 'desc', per_page: 100 } })
-                 .then(function(contribData) {
-                   var headers = contribData;
-                   var parsed = toolbox.parse(headers['link']);
-                   totalPages = parseInt(parsed.last.page);
-                   return totalPages;
-                 });
-
-          //define totalContributors
-          var totalContributors = 0;
-
-          // get data given the page number
-          function getData(curPage){
-            toolbox.api.Repositories
-                   .getRepoContributors(org, repo, { method:"GET", qs: { sort: 'pushed', direction: 'desc', per_page: 100, page:curPage } })
-                   .then(function(contributors) {
-                     //contributors = contributors.body;
-                     var usernames = contributors.map(function(c) {
-                       return '<a href="https://github.com/' + c.login + '">@' + c.login + '</a>';
-                     });
-                     var avatars = contributors.map(function(c) {
-                       return '<a href="https://github.com/' + c.login + '"><img width="100px" src="' + c.avatar_url + '"></a>';
-                     });
-                     totalContributors += contributors.length;
-                     $('.contributors-head').html('Contributors ('+totalContributors+')');
-                     $('.contributors > .usernames').append(usernames.join(', '));
-                     $('.contributors > .avatars').append(avatars.join());
-                   });
-          }
-
-          var curPage = 1;
-          getPages.then(function(totalPages){
-            for(var i = curPage; i <= totalPages; i++) {
-            	getData(i);
-            }
-          });
+          toolbox.getRepoContributors(org, repo);
 
 	}
 

--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
 
       <h2>What's next?</h2>
 
-      <p>Once you've completed a <b>first-timers-only</b> issue, there are <a href="https://github.com/publiclab/plots2/labels/help-wanted">plenty of other challenges</a> we'd love to have your help on.</p> 
+      <p>Once you've completed a <b>first-timers-only</b> issue, there are <a href="https://github.com/publiclab/plots2/labels/help-wanted">plenty of other challenges</a> we'd love to have your help on.</p>
 
       <p>In "Candidates" above, there are some issues we think would make good <b>first-timers-only</b> issues, but haven't finished formatting. They could make a good second-time contribution!</p>
 
@@ -90,18 +90,18 @@
 
       <hr />
 
-      <h2>Contributors</h2>
+      <h2 class="contributors-head">Contributors</h2>
 
       <p>This project was made possible by many contributors, including the following GitHub users:</p>
 
-      <p class="well contributors"></p>
+      <div class="well contributors"><p class="usernames"></p><p class="avatars"></p></div>
 
     </div>
 
     <footer>
       <p>
         Page powered by <a href="https://github.com/jywarren/community-toolbox"><i class="fa fa-github"></i></a>
-        <a href="https://github.com/jywarren/community-toolbox">Commmunity Toolbox</a> 
+        <a href="https://github.com/jywarren/community-toolbox">Commmunity Toolbox</a>
         - Open Source
       </p>
     </footer>
@@ -116,7 +116,7 @@
         var repo = urlHash().getUrlHashParameter('r') || 'plots2';
         var ftoLabel = urlHash().getUrlHashParameter('f') || 'first-timers-only';
         var candidateLabel = urlHash().getUrlHashParameter('c') || 'fto-candidate';
-    
+
         toolbox = CommunityToolbox(org, repo);
 
 	if (repo === 'all') {
@@ -138,19 +138,45 @@
                  .then(displayIssues('.candidates'));
 
           // compile and display all contributors for given org/repo:
-          toolbox.api.Repositories
-                 .getRepoContributors(org, repo, { qs: { sort: 'pushed', direction: 'desc', per_page: 100 } })
-                 .then(function(contributors) {
-                   var usernames = contributors.map(function(c) { 
-                     return '<a href="https://github.com/' + c.login + '">@' + c.login + '</a>';
-                   });
-                   var avatars = contributors.map(function(c) { 
-                     return '<a href="https://github.com/' + c.login + '"><img width="100px" src="' + c.avatar_url + '"></a>';
-                   });
-                   $('.contributors').html(usernames.join(', '));
-                   $('.contributors').append('<hr />');
-                   $('.contributors').append(avatars.join());
+          // get number of pages
+          var getPages = toolbox.api.Repositories
+                 .getRepoContributors(org, repo, {method: "HEAD", qs: { sort: 'pushed', direction: 'desc', per_page: 100 } })
+                 .then(function(contribData) {
+                   var headers = contribData;
+                   var parsed = toolbox.parse(headers['link']);
+                   totalPages = parseInt(parsed.last.page);
+                   return totalPages;
                  });
+
+          //define totalContributors
+          var totalContributors = 0;
+
+          // get data given the page number
+          function getData(curPage){
+            toolbox.api.Repositories
+                   .getRepoContributors(org, repo, { method:"GET", qs: { sort: 'pushed', direction: 'desc', per_page: 100, page:curPage } })
+                   .then(function(contributors) {
+                     //contributors = contributors.body;
+                     var usernames = contributors.map(function(c) {
+                       return '<a href="https://github.com/' + c.login + '">@' + c.login + '</a>';
+                     });
+                     var avatars = contributors.map(function(c) {
+                       return '<a href="https://github.com/' + c.login + '"><img width="100px" src="' + c.avatar_url + '"></a>';
+                     });
+                     totalContributors += contributors.length;
+                     $('.contributors-head').html('Contributors ('+totalContributors+')');
+                     $('.contributors > .usernames').append(usernames.join(', '));
+                     $('.contributors').append('<hr />');
+                     $('.contributors > .avatars').append(avatars.join());
+                   });
+          }
+
+          var curPage = 1;
+          getPages.then(function(totalPages){
+            for(var i = curPage; i <= totalPages; i++) {
+            	getData(i);
+            }
+          });
 
 	}
 

--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
 
       <p>This project was made possible by many contributors, including the following GitHub users:</p>
 
-      <div class="well contributors"><p class="usernames"></p><p class="avatars"></p></div>
+      <div class="well contributors"><p class="usernames"></p><hr /><p class="avatars"></p></div>
 
     </div>
 
@@ -166,7 +166,6 @@
                      totalContributors += contributors.length;
                      $('.contributors-head').html('Contributors ('+totalContributors+')');
                      $('.contributors > .usernames').append(usernames.join(', '));
-                     $('.contributors').append('<hr />');
                      $('.contributors > .avatars').append(avatars.join());
                    });
           }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "chart.js": "~2.7.0",
     "font-awesome": "~4.5.0",
     "jquery": "~2",
+    "parse-link-header": "^1.0.1",
     "urlhash": "~0.1.1"
   },
   "devDependencies": {

--- a/src/community-toolbox.js
+++ b/src/community-toolbox.js
@@ -39,11 +39,44 @@ CommunityToolbox = function CommunityToolbox(org, repo) {
        .then(callback);
   }
 
-  function getRepoContributors(callback, _options) {
-    _options = _options || options;
-    api.Repositories
-       .getRepoContributors(org, repo, _options)
-       .then(callback);
+  function getRepoContributors(org, repo) {
+
+    var getPages = api.Repositories
+           .getRepoContributors(org, repo, {method: "HEAD", qs: { sort: 'pushed', direction: 'desc', per_page: 100 } })
+           .then(function(contribData) {
+             var headers = contribData;
+             var parsed = parse(headers['link']);
+             totalPages = parseInt(parsed.last.page);
+             return totalPages;
+           });
+
+    //define totalContributors
+    var totalContributors = 0;
+
+    // get data given the page number
+    function getData(curPage){
+      api.Repositories
+            .getRepoContributors(org, repo, { method:"GET", qs: { sort: 'pushed', direction: 'desc', per_page: 100, page:curPage } })
+            .then(function(contributors) {
+              var usernames = contributors.map(function(c) {
+                return '<a href="https://github.com/' + c.login + '">@' + c.login + '</a>';
+              });
+              var avatars = contributors.map(function(c) {
+                return '<a href="https://github.com/' + c.login + '"><img width="100px" src="' + c.avatar_url + '"></a>';
+              });
+              totalContributors += contributors.length;
+              //push data to UI
+              ui.insertContributors(totalContributors, usernames, avatars);
+            });
+    }
+
+    var promises = [];
+    getPages.then(function(totalPages){
+      for(var i = 1; i <= totalPages; i++) {
+        getData(i);
+      }
+    });
+
   }
 
   function displayIssuesForRepo(org, repo, label, selector) {

--- a/src/community-toolbox.js
+++ b/src/community-toolbox.js
@@ -5,18 +5,19 @@ CommunityToolbox = function CommunityToolbox(org, repo) {
   var api = new SimpleApi();
   var ui = require('./ui');
   const requestP = require('request-promise');
+  var parse = require('parse-link-header');
 
   var options = {
     'qs': {
       'sort': 'pushed',
-      'direction': 'desc', // optional, GitHub API uses 'desc' by default for 'pushed' 
+      'direction': 'desc', // optional, GitHub API uses 'desc' by default for 'pushed'
       'per_page': 100
     }
   }
 
-  // these are essentially examples for now; we could wrap them 
-  // in externally available methods for convenience but at the 
-  // moment they're not quite complex enough to merit it. 
+  // these are essentially examples for now; we could wrap them
+  // in externally available methods for convenience but at the
+  // moment they're not quite complex enough to merit it.
 
   function getIssuesForRepo(callback, _options) {
     _options = _options || options;
@@ -61,6 +62,7 @@ CommunityToolbox = function CommunityToolbox(org, repo) {
   return {
     api:     api,
     ui:      ui,
+    parse:   parse,
     chart:   chart,
     options: options,
     getIssuesForRepo: getIssuesForRepo,

--- a/src/ui.js
+++ b/src/ui.js
@@ -28,7 +28,19 @@ function insertIssue(issue, el) {
   $(el).append(generateIssueHtml(issue.title, body, issue.html_url, issue));
 }
 
+//Check if function executed so we can add a comma
+var insertContributorsExec = false;
+
+function insertContributors(totalContributors, usernames, avatars){
+  if(insertContributorsExec) $('.contributors > .usernames').append(', ');
+  $('.contributors-head').html('Contributors ('+totalContributors+')');
+  $('.contributors > .usernames').append(usernames.join(', '));
+  $('.contributors > .avatars').append(avatars.join());
+  insertContributorsExec=true;
+}
+
 module.exports = {
   generateIssueHtml: generateIssueHtml,
-  insertIssue: insertIssue
+  insertIssue: insertIssue,
+  insertContributors: insertContributors
 };


### PR DESCRIPTION
This fixes #10 and also adds support for GitHub paginated requests while displaying repository contributors.

Added dependency: `parse-link-header` (MIT License)

*Note*: Pages may not load in ascending order. This means page 2 might load before page 1 (top contributors) due to asynchronous nature of `request-promise`.