### PR TITLE
Combined contributors list with profile pics does not show on multi-repository view

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,6 +161,7 @@
 
           toolbox.getIssuesForOrg(org, { qs: { labels: candidateLabel } })
                  .then(displayIssues('.candidates'));
+	toolbox.getRepoContributors(org, repo);
 
 	} else {
 


### PR DESCRIPTION
# Combined contributors list with profile pics does not show on multi-repository view
Closes #29 