### PR TITLE
Adding simple 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Page Not Found</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+
+        * {
+            line-height: 1.2;
+            margin: 0;
+        }
+
+        html {
+            color: #888;
+            display: table;
+            font-family: sans-serif;
+            height: 100%;
+            text-align: center;
+            width: 100%;
+        }
+
+        body {
+            display: table-cell;
+            vertical-align: middle;
+            margin: 2em auto;
+        }
+
+        h1 {
+            color: #555;
+            font-size: 2em;
+            font-weight: 400;
+        }
+
+        p {
+            margin: 0 auto;
+            width: 280px;
+        }
+
+        @media only screen and (max-width: 280px) {
+
+            body, p {
+                width: 95%;
+            }
+
+            h1 {
+                font-size: 1.5em;
+                margin: 0 0 0.3em;
+            }
+
+        }
+
+    </style>
+</head>
+<body>
+    <h1>Page Not Found</h1>
+    <p>Sorry, but the page you were trying to view does not exist.</p>
+</body>
+</html>
+<!-- IE needs 512+ bytes: https://blogs.msdn.microsoft.com/ieinternals/2010/08/18/friendly-http-error-pages/ -->

--- a/404.html
+++ b/404.html
@@ -44,7 +44,7 @@
             }
 
             h1 {
-                font-size: 1.5em;
+                font-size: 5em;
                 margin: 0 0 0.3em;
             }
 
@@ -54,6 +54,7 @@
 </head>
 <body>
     <h1>Page Not Found</h1>
+    <br>
     <p>Sorry, but the page you were trying to view does not exist.</p>
 </body>
 </html>

--- a/404.html
+++ b/404.html
@@ -58,4 +58,3 @@
     <p>Sorry, but the page you were trying to view does not exist.</p>
 </body>
 </html>
-<!-- IE needs 512+ bytes: https://blogs.msdn.microsoft.com/ieinternals/2010/08/18/friendly-http-error-pages/ -->


### PR DESCRIPTION
Fixes #149

* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts
* [x] PR is descriptively titled
* [x] PR body includes `fixes #0000`-style reference to original issue #
* [x] ask `@publiclab/reviewers` for help, in a comment below

Adding simple 404 page
Now , as repo does not have 404 page so.github is throwing its own default file for handling 404 request
if we add 404 file to our repo github will automatically detect it and will show it instead of its own error file


## Simple 404 page ( suggestion are welcomed )
![4](https://user-images.githubusercontent.com/34541684/53810703-8a951a00-3f7d-11e9-959d-7c3b61ebccdc.png)
