### PR TITLE
center the avatars in contribution list

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,7 +144,7 @@
 
       <p>This project was made possible by many contributors, including the following GitHub users:</p>
 
-      <div class="well contributors"><div id="spinner-icon" style="text-align: center;"><i class="fa fa-spinner fa-spin"></i></div><p class="usernames"></p><hr /><p class="avatars"></p></div>
+      <div class="well contributors"><div id="spinner-icon" style="text-align: center;"><i class="fa fa-spinner fa-spin"></i></div><p class="usernames"></p><hr /><p class="avatars text-center"></p></div>
 
     </div>
 


### PR DESCRIPTION
Fixed #187 

* [X] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts
* [X] PR is descriptively titled
* [X] PR body includes `fixes #0000`-style reference to original issue #
* [X] ask `@publiclab/reviewers` for help, in a comment below

**Changes**
- Added text-center class to p in div.contributors (list of contributors) which resulted in centering of the contribution list.

**Screenshot of changes**
![contribution-list](https://user-images.githubusercontent.com/42073855/56455904-27ace600-6365-11e9-829d-578be02bcefc.JPG)

