### PR TITLE
Add fallback for dark theme when localStorage isn't available

### DIFF
--- a/examples/themes.js
+++ b/examples/themes.js
@@ -81,7 +81,6 @@
         }else {
           localStorage.setItem('currentToggle', 'night');
           toggle = 'night';
-          alert('niiight');
           body.style.backgroundColor = '#111111';
           body.style.filter = 'invert(1)';
           body.style.transitionProperty = 'filter';

--- a/examples/themes.js
+++ b/examples/themes.js
@@ -4,7 +4,7 @@
   $(document).ready(() => {
     let body=document.querySelector('body');
     let toggleButton=document.getElementById('myonoffswitch');
-    let toggle = localStorage.getItem('currentToggle');
+    let toggle = localStorage.getItem('currentToggle') || 'day';
 
     // Sets images' theme accordingly when the page is loaded
     setTimeout(()=> {
@@ -57,10 +57,10 @@
 
       setTimeout(()=> {
         let images=document.querySelectorAll("img");
-        let check=localStorage.getItem('currentToggle');
         
-        if(check==="night") {
+        if(toggle==="night") {
           localStorage.setItem('currentToggle', 'day');
+          toggle = 'day';
           body.style.backgroundColor = '#f8f8fa';
           body.style.filter = 'invert(0)';
           body.style.transitionProperty = 'filter';
@@ -80,6 +80,8 @@
 
         }else {
           localStorage.setItem('currentToggle', 'night');
+          toggle = 'night';
+          alert('niiight');
           body.style.backgroundColor = '#111111';
           body.style.filter = 'invert(1)';
           body.style.transitionProperty = 'filter';


### PR DESCRIPTION
Make the dark theme work on browsers that have disabled cookies and localStorage access

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [x] code is in uniquely-named feature branch and has no merge conflicts
* [x] PR is descriptively titled
* [x] PR body includes `fixes #0000`-style reference to original issue #
* [x] ask `@publiclab/reviewers` for help, in a comment below